### PR TITLE
Avoid crash on paint_active_slot in Blender 2.93

### DIFF
--- a/mixer/blender_data/attributes.py
+++ b/mixer/blender_data/attributes.py
@@ -189,7 +189,11 @@ def write_attribute(
             finally:
                 context.visit_state.pop()
 
-        else:
+        else:                
+            if hasattr(parent, 'paint_active_slot'):
+                logger.warning("Avoid crash for paint_active_slot")
+                logger.warning(f"... attribute: {context.visit_state.display_path()}.{key}, value: {value}")
+                return
             assert isinstance(key, str)
 
             prop = parent.bl_rna.properties.get(key)


### PR DESCRIPTION
Fixes: https://github.com/ubisoft/mixer/issues/20
Fixes: https://github.com/ubisoft/mixer/issues/18
Fixes: https://github.com/ubisoft/mixer/issues/26

Can someone test?

I don't like the location of key check. Any better designs?